### PR TITLE
Neovim fix window highlight group configs

### DIFF
--- a/.config/nvim/lua/chadrc.lua
+++ b/.config/nvim/lua/chadrc.lua
@@ -6,10 +6,23 @@
 local M = {}
 
 M.base46 = {
-  theme = "rosepine",
-  integrations = { "avante" },
+  theme = "catppuccin",
+  integrations = { "avante", "nvimtree", "telescope" },
   hl_add = {
-    ["AvanteSidebarWinSeparator"] = { fg = "black", bg = "black", link = "NONE" },
+    ["AvanteSidebarWinSeparator"] = {
+      fg = "one_bg2",
+      bg = "black",
+    },
+    -- ["AvanteVertSplit"] = {
+    --   fg = "darker_black",
+    --   bg = "darker_black",
+    -- },
+    ["AvanteSidebarNormal"] = {
+      bg = "black",
+    },
+    ["AvanteSidebarWinHorizontalSeparator"] = {
+      fg = "black",
+    },
   },
   hl_override = {
     NvimTreeWinSeparator = {

--- a/.config/nvim/lua/chadrc.lua
+++ b/.config/nvim/lua/chadrc.lua
@@ -6,27 +6,30 @@
 local M = {}
 
 M.base46 = {
-    theme = "rosepine",
-    integrations = { "avante" },
-    hl_override = {
-        NvimTreeWinSeparator = {
-            fg = "black",
-            bg = "black",
-        },
+  theme = "rosepine",
+  integrations = { "avante" },
+  hl_add = {
+    ["AvanteSidebarWinSeparator"] = { fg = "black", bg = "black", link = "NONE" },
+  },
+  hl_override = {
+    NvimTreeWinSeparator = {
+      fg = "black",
+      bg = "black",
     },
+  },
 }
 
 M.nvdash = { load_on_startup = true }
 
 M.ui = {
-    tabufline = {
-        lazyload = false,
-    },
+  tabufline = {
+    lazyload = false,
+  },
 
-    statusline = {
-        theme = "default",
-        separator_style = "round",
-    },
+  statusline = {
+    theme = "default",
+    separator_style = "round",
+  },
 }
 
 -- M.lsp = { signature = false }

--- a/.config/nvim/lua/custom/configs/avante.lua
+++ b/.config/nvim/lua/custom/configs/avante.lua
@@ -25,6 +25,18 @@ M.setup = function()
       "delete_dir",
       "bash",
     },
+    behavior = {
+      enable_token_counting = false,
+    },
+    windows = {
+      sidebar_header = {
+        enabled = true,
+        -- align = "left",
+        rounded = true,
+      },
+    },
+
+    auto_set_highlight_group = false,
   }
 
   M.set_keymaps()


### PR DESCRIPTION
Avante's highlight group logic is deeply convoluted and gross and it needlessly overrides neovim/nvchad's highlight group values by linking itself to them.